### PR TITLE
update Flask to fix bug

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
+Flask==2.1.0
 Flask-Cors==3.0.9
 Flask-RESTful==0.3.8
 git+https://github.com/huggingface/transformers.git


### PR DESCRIPTION
I was getting the error: ImportError: cannot import name 'escape' from 'jinja2' (/Users/matthieu/Coding/dalle-playground/dalle-playground/backend/venv/lib/python3.9/site-packages/jinja2/__init__.py)