### PR TITLE
DOC: Use the same python app we were using a few lines above

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Follow these steps in case you'd like to clone and run the DALL-E playground loc
 3. Install requirements `pip install -r requirements.txt`
 4. Make sure you have pytorch and its dependencies
    installed _[Installation guide](https://pytorch.org/get-started/locally/)_
-5. Run web server `python app.py 8080` (you can change from 8080 to your own port)
+5. Run web server `python3 app.py 8080` (you can change from 8080 to your own port)
 6. In a different terminal, install frontend's modules `cd interface && npm install` and run
    it `npm start`
 7. Copy backend's url from step 5 and paste it in the backend's url input within the web app


### PR DESCRIPTION
Ran into this because my default local python is 2.x, and got this error: 
```
brandyn@Brandyns-MacBook-Pro backend % python app.py 8080
  File "app.py", line 32
    print(f"Created {num_images} images from text prompt [{text_prompt}]")
```

Easy fix was to just use python3!