### PR TITLE
Enforce use of http or https for backend url

### DIFF
--- a/interface/src/BackendUrlInput.js
+++ b/interface/src/BackendUrlInput.js
@@ -54,7 +54,7 @@ const BackendUrlInput = ({
                 <TextField className={classes.inputBackend} fullWidth id="standard-basic"
                            label="Backend URL" value={backendUrl} disabled={disabled}
                            error={!isValidBackendEndpoint && backendUrl !== ''}
-                           helperText={!isValidBackendEndpoint && backendUrl !== '' && "No running DALL-E server with this URL"}
+                           helperText={!isValidBackendEndpoint && backendUrl !== '' && "No running DALL-E server with this URL (Remember to include URL protocol prefix)"}
                            onChange={(event) => onChange(event.target.value)}/>
             </Grid>
             {isCheckingBackendEndpoint && <Grid item className={classes.loadingSpinner} xs={2}>

--- a/interface/src/utils.js
+++ b/interface/src/utils.js
@@ -1,5 +1,5 @@
 export function isValidURL(str) {
-  const pattern = new RegExp('^(https?:\\/\\/)?'+ // protocol
+  const pattern = new RegExp('^https?:\\/\\/'+ // protocol
     '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // domain name
     '((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
     '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path


### PR DESCRIPTION
No need to allow backend url to be entered without http or https, so enforcing the use of url prefix, for more novice users to not get confused, also to ensure more explicit enforcement of rules. 

In addtion, added a note to users to remember that if the backend url isn't working, it could be due to leaving out the url prefix. To address issues raised: #40 @VeXHarbinger @saharmor @kamalkraj 