### PR TITLE
Fix for mode no-cors property to fetch

### DIFF
--- a/interface/src/backend_api.js
+++ b/interface/src/backend_api.js
@@ -7,9 +7,9 @@ export async function callDalleService(backendUrl, text, numImages) {
     const response = await Promise.race([
         (await fetch(backendUrl + `/dalle`, {
                 method: 'POST',
+                mode: 'no-cors',
                 headers: {
                     'Bypass-Tunnel-Reminder': "go",
-                    'mode': 'no-cors'
                 },
                 body: JSON.stringify({
                     text,


### PR DESCRIPTION
Addresses #67 - The `mode` property to fetch [needs to be root-level](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#supplying_request_options), rather than a header.

It looks like app.py is using the flask_cors package, so not sure why `Access-Control-Allow-Origin` header isn't being set. 