### PR TITLE
Allow #root to be larger than 100vh

### DIFF
--- a/interface/src/App.css
+++ b/interface/src/App.css
@@ -7,7 +7,7 @@ body {
 }
 
 #root {
-    height: 100vh;
+    min-height: 100vh;
     background-color: #f6f6ef;
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
While this only impacts visual appearance, setting the height of the element to a fixed 100vh causes the background of the page to be unstyled if the page should become longer than one screen height. Change this to min-height allows the background to expand to fill the whole page.