### PR TITLE
flask-cloudflared instead of localtunnel

### DIFF
--- a/backend/dalle_playground_backend.ipynb
+++ b/backend/dalle_playground_backend.ipynb
@@ -34,7 +34,7 @@
       "source": [
         "!git clone https://github.com/saharmor/dalle-playground.git\n",
         "!pip install -r dalle-playground/backend/requirements.txt\n",
-        "!npm install -g localtunnel"
+        "!pip install flask-cloudflared"
       ]
     },
     {
@@ -72,12 +72,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "# Run the backend web server"
-      ],
       "metadata": {
         "id": "sqF_iNGmmVIC"
-      }
+      },
+      "source": [
+        "# Run the backend web server"
+      ]
     },
     {
       "cell_type": "code",
@@ -87,17 +87,48 @@
       },
       "outputs": [],
       "source": [
-        "from threading import Thread\n",
+        "from threading import Thread, Event\n",
         "\n",
         "app_port = 8000\n",
+        "announce_url = None\n",
+        "cloudflared_startup = Event()\n",
+        "\n",
+        "def update_announce_url(url):\n",
+        "    global announce_url\n",
+        "    announce_url = url\n",
+        "\n",
+        "def start_cloudflared(port):\n",
+        "  from flask_cloudflared import _run_cloudflared\n",
+        "  try:\n",
+        "    announce_url = _run_cloudflared(port)\n",
+        "  except:\n",
+        "    raise\n",
+        "  finally:\n",
+        "    update_announce_url(announce_url)\n",
+        "    cloudflared_startup.set()\n",
+        "\n",
+        "def run_with_cloudflared(thread):\n",
+        "    old_run = thread.run\n",
+        "\n",
+        "    def new_run(*args, **kwargs):\n",
+        "        new_thread = Thread(target = start_cloudflared, args=(app_port,))\n",
+        "        new_thread.setDaemon(True)\n",
+        "        new_thread.start()\n",
+        "        old_run(*args, **kwargs)\n",
+        "\n",
+        "    thread.run = new_run\n",
+        "\n",
         "def app():\n",
         "  print(f\"Selected DALL-E Model - [{dalle_model}]\")\n",
         "  !python dalle-playground/backend/app.py --port {app_port} --model_version {dalle_model} --save_to_disk true --img_format jpeg --output_dir generations\n",
         "\n",
         "if __name__ == '__main__':\n",
         "    t1 = Thread(target = app)\n",
-        "    a = t1.start()\n",
-        "    !lt --port {app_port}"
+        "    run_with_cloudflared(t1)\n",
+        "    t1.start()\n",
+        "    cloudflared_startup.wait()\n",
+        "    print(f\"your url is: {announce_url}\")\n",
+        "    t1.join()"
       ]
     },
     {
@@ -106,7 +137,7 @@
         "id": "UPhc5fgqT_Q0"
       },
       "source": [
-        "### Now, take the url you got from localtunnel (should look like `your url is: https://xxxxxx.loca.lt`), replace it within the url here https://saharmor.github.io/dalle-playground/?backendUrl=https://xxxxxx.loca.lt and run it in the browser. \n",
+        "### Now, take the url you got from cloudflare (should look like `your url is: https://xxxxxx.trycloudflare.com`), replace it within the url here https://saharmor.github.io/dalle-playground/?backendUrl=https://xxxxxx.trycloudflare.com and run it in the browser.\n",
         "\n",
         "### Let the fun begin ✨"
       ]


### PR DESCRIPTION
Unsure if this is the correct direction, but whipped this up after getting frustrated.
I tried writing up an alternate version that spawns cloudflared on the terminal instead of the backend, but in theory it's way more useful to see the backend/service messages, instead of a non-printing cloudflare thread.
So it'll spawn both threads, then once it gets the announcement URL, it joins back to the app thread to keep things running.

There's an alternate (shorter) version on my TheGoddessInari/dalle-playground@e279b78 cloudflare branch, but I'm out of free Collab testing time for the moment.

I know it's probably just another blip in localtunnel, but this is virtually a drop-in replacement, and doesn't have the account issues reported of ngrok.

Fixes #94.