### PR TITLE
MEGA_FULL needs dtype = jnp.float32

### DIFF
--- a/backend/dalle_model.py
+++ b/backend/dalle_model.py
@@ -48,7 +48,7 @@ class DalleModel:
     def __init__(self, model_version: ModelSize) -> None:
         if model_version == ModelSize.MEGA_FULL:
             dalle_model = DALLE_MODEL_MEGA_FULL
-            dtype = jnp.float16
+            dtype = jnp.float32
         elif model_version == ModelSize.MEGA:
             dalle_model = DALLE_MODEL_MEGA
             dtype = jnp.float16


### PR DESCRIPTION
Currently, running the MEGA_FULL version gives a warning about mismatched float16 vs float32 dtypes. This changes fixes the issue, which makes sense as I believe MEGA_FULL uses float32.