### PR TITLE
Update requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ flask_cloudflared
 accelerate
 transformers
 diffusers
+werkzeug==2.2.2


### PR DESCRIPTION
Recently, the version of the werkzeug package has been updated to >=3.0.0. It will raise an error of "ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/opt/conda/lib/python3.10/site-packages/werkzeug/urls.py)".